### PR TITLE
fix(morpho): fix override of underlying mapping

### DIFF
--- a/src/mapping/morpho-aave-v3/morpho-aave-v3.ts
+++ b/src/mapping/morpho-aave-v3/morpho-aave-v3.ts
@@ -321,13 +321,13 @@ export function handleMarketCreated(event: MarketCreated): void {
 
   // Add the underlying tokens mapping
   let underlyingMapping = UnderlyingTokenMapping.load(event.params.underlying);
-  if (underlyingMapping == null) {
+  if (underlyingMapping == null)
     underlyingMapping = new UnderlyingTokenMapping(event.params.underlying);
-  }
+
   underlyingMapping.variableDebtTokenV3 = morphoMarket.variableDebtToken;
   underlyingMapping.aTokenV3 = morphoMarket.aToken;
-  underlyingMapping.aToken = Address.zero();
-  underlyingMapping.debtToken = Address.zero();
+  if (!underlyingMapping.aToken) underlyingMapping.aToken = Address.zero();
+  if (!underlyingMapping.debtToken) underlyingMapping.debtToken = Address.zero();
   underlyingMapping.save();
 
   market.inputTokenBalance = underlying.balanceOf(morphoMarket.aToken);


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
- token mapping was overriding the aToken & debtToken for aavev2 address when initializing ma3. 
- It leads to markets that are both on aaveV2 & aavev3 has aToken defined to zero on the underlying mapping. As a consequence, when a lending pool emits a ReserveUpdate, the token mapping cannot found the aToken address, and considers that  the market is not on morpho, without triggering an update

- The fix is only to not override an existing token mapping
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->