### PR TITLE
fix(aave-v3): initialize _p2pIndexCursor_BI before event emitted

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1024,7 +1024,7 @@ export function updateP2PRates(market: Market, __MATHS__: IMaths): void {
     market._p2pBorrowIndexFromRates,
     market._p2pIndexCursor_BI,
     market._p2pBorrowDelta,
-    market._p2pSupplyAmount,
+    market._p2pBorrowAmount,
     market._reserveFactor_BI,
     proportionIdle,
     __MATHS__

--- a/src/mapping/morpho-aave-v3/morpho-aave-v3.ts
+++ b/src/mapping/morpho-aave-v3/morpho-aave-v3.ts
@@ -405,6 +405,7 @@ export function handleMarketCreated(event: MarketCreated): void {
   market.reserveFactor = BigDecimal.zero(); // Event is emitted right after the market creation
   market._reserveFactor_BI = BigInt.zero();
   market.p2pIndexCursor = BigDecimal.zero(); // Event is emitted right after the market creation
+  market._p2pIndexCursor_BI = BigInt.zero();
 
   market.totalSupplyOnPool = BigDecimal.zero();
   market.totalCollateralOnPool = BigDecimal.zero();


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Initialize `_p2pIndexCursor_BI` to zero on market initialization for AAVE V3, and fixes a small bug (`_p2pBorrowAmount` instead of `_p2pSupplyAmount`).

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->